### PR TITLE
Use closure instead of overwrite

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var through    = require("through2");
 
-var WRAP_BEGIN = '__rotta_define = window.define; window.define = null;'
-var WRAP_END   = 'window.define = __rotta_define;'
+var WRAP_BEGIN = '(function () { var define = undefined;'
+var WRAP_END   = '})();'
 
 module.exports = function (browserify, opts) {
     var createStream = function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserify-dedefine",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "browserify-dedefine",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Wrap browserified bundle inside a closure and overwrite `define` to `undefined` there instead of overwriting global `define`